### PR TITLE
Changed keys to conform to webpack 2

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
-const path = require('path');
-const CopyWebpackPlugin = require('copy-webpack-plugin');
+const path = require('path')
+const CopyWebpackPlugin = require('copy-webpack-plugin')
 
 module.exports = {
   entry: './app/javascripts/app.js',
@@ -10,23 +10,20 @@ module.exports = {
   plugins: [
     // Copy our app's index.html to the build folder.
     new CopyWebpackPlugin([
-      { from: './app/index.html', to: "index.html" }
+      { from: './app/index.html', to: 'index.html' }
     ])
   ],
   module: {
     rules: [
       {
-       test: /\.css$/,
-       use: [ 'style-loader', 'css-loader' ]
-      }
-    ],
-    loaders: [
-      { test: /\.json$/, use: 'json-loader' },
+        test: /\.css$/,
+        use: [ 'style-loader', 'css-loader' ]
+      },
       {
         test: /\.js$/,
         exclude: /(node_modules|bower_components)/,
         loader: 'babel-loader',
-        query: {
+        options: {
           presets: ['es2015'],
           plugins: ['transform-runtime']
         }


### PR DESCRIPTION
There was a mix use of Webpack 2 and Webpack 1. Made it all Webpack 2 for consistency.

I followed the [migration](https://webpack.js.org/guides/migrating/) guide for webpack. Basically changed keys from `loader` to `use. Removed the json-loader because webpack2 will add it automatically. 

@tcoulter