### PR TITLE
Use promise to avoid race condition

### DIFF
--- a/test/metacoin.js
+++ b/test/metacoin.js
@@ -11,7 +11,6 @@ contract('MetaCoin', function(accounts) {
   it("should call a function that depends on a linked library", function() {
     var meta;
     var metaCoinBalance;
-    var metaCoinEthBalance;
 
     return MetaCoin.deployed().then(function(instance) {
       meta = instance;
@@ -20,9 +19,9 @@ contract('MetaCoin', function(accounts) {
       metaCoinBalance = outCoinBalance.toNumber();
       return meta.getBalanceInEth.call(accounts[0]);
     }).then(function(outCoinBalanceEth) {
-      metaCoinEthBalance = outCoinBalanceEth.toNumber();
-    }).then(function() {
-      assert.equal(metaCoinEthBalance, 2 * metaCoinBalance, "Library function returned unexpeced function, linkage may be broken");
+      return outCoinBalanceEth.toNumber();
+    }).then(function(metaCoinEthBalance) {
+      assert.equal(metaCoinEthBalance, 2 * metaCoinBalance, "Library function returned unexpected function, linkage may be broken");
     });
   });
 


### PR DESCRIPTION
There is a small issue in the "should call a function that depends on a linked library" test, which means that:

`assert.equal(metaCoinEthBalance, 2 * metaCoinBalance, "Library function returned unexpected function, linkage may be broken");`

may be called before metaCoinEthBalance is set and fail. I see this fail sporadically, but the issue can be replicated by replacing:

`metaCoinEthBalance = outCoinBalanceEth.toNumber();`

with:

`setTimeout(function() {metaCoinEthBalance = outCoinBalanceEth.toNumber();}, 1000);`

Failure is then:

```
  1) Contract: MetaCoin should call a function that depends on a linked library:
     AssertionError: Library function returned unexpeced function, linkage may be broken: expected undefined to equal 20000
      at test/metacoin.js:25:14
      at process._tickCallback (internal/process/next_tick.js:103:7)

```

Issue is corrected by returning from inside the then statement and forcing the promise to chain correctly.