### PR TITLE
Fixing Migrations.sol:11:3: Warning - Use "constructor(...)

### DIFF
--- a/contracts/Migrations.sol
+++ b/contracts/Migrations.sol
@@ -8,7 +8,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() {
+  constructor() {
     owner = msg.sender;
   }
 


### PR DESCRIPTION
Fixing warning message in Migrations.sol

Migrations.sol:11:3: Warning: Defining constructors as functions with the same name as the contract is deprecated. Use "constructor(...) { ... }" instead.
